### PR TITLE
Add requirements to requirements.txt

### DIFF
--- a/TreaBot.bat
+++ b/TreaBot.bat
@@ -1,5 +1,5 @@
 @echo off
-title TreeBot
+title TreaBot
 echo Activating Venv
 venv\Scripts\activate
 echo Sprouting Trea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py
+aiohttp[speedups]
+apscheduler


### PR DESCRIPTION
This was empty which made it harder to figure out what all TreaBot used. With this people can just do `pip3 -r requirements.txt` and get the bot running a little bit faster